### PR TITLE
Restores default scrolling action onReset

### DIFF
--- a/jquery.wheelzoom.js
+++ b/jquery.wheelzoom.js
@@ -116,6 +116,8 @@
 					// Prevent zooming out beyond the starting size
 					if (bgWidth <= width || bgHeight <= height) {
 						reset();
+						//might as well provide a little scrolly scrolly!
+                                                jQuery('body').scrollTop(jQuery(window).scrollTop() + 60);
 					} else {
 						updateBgStyle();
 					}


### PR DESCRIPTION
When zoomed all the way back out, allows user to return to known work-flow of scrolling down the page. 
Scrolling up will still trigger as normal. Tested.

Also means that an image won't block a normal scroll use of the page when user isn't interested in zooming, but the image happens to be beneath the mouse (downwards scrolling had no effect on page when image was beneath cursor).
Change only uses API function: http://api.jquery.com/scrolltop/

60 is in pixels, so needs to be enough that it doesn't affect the normal use of the wheel.
